### PR TITLE
Sanitize filter read_length input

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,0 +1,114 @@
+
+import subprocess
+import tempfile
+import unittest
+import os.path as op
+
+from pbcoretools.tasks.filters import (run_filter_dataset,
+                                       sanitize_read_length)
+from pbcore.io import openDataFile, openDataSet
+import pbcore.data.datasets as data
+
+from pbcoretools import bamSieve
+
+class TestFilterDataSet(unittest.TestCase):
+
+    def test_dataset_io(self):
+        ssfn = data.getXml(8)
+        ofn = tempfile.NamedTemporaryFile(suffix=".xml").name
+
+        # some smoke tests:
+        run_filter_dataset(ssfn, ofn, "", "")
+        run_filter_dataset(ssfn, ofn, 0, "")
+        run_filter_dataset(ssfn, ofn, 0, "None")
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, "None", "None")
+        run_filter_dataset(ssfn, ofn, None, None)
+        run_filter_dataset(ssfn, ofn, 0, 0)
+        run_filter_dataset(ssfn, ofn, False, False)
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, True, False)
+        run_filter_dataset(ssfn, ofn, False, True)
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, True, True)
+        run_filter_dataset(ssfn, ofn, 1, True)
+        run_filter_dataset(ssfn, ofn, "0", "None")
+        run_filter_dataset(ssfn, ofn, " 0 ", "None")
+        run_filter_dataset(ssfn, ofn, "-1", "none")
+        run_filter_dataset(ssfn, ofn, " -1 ", "none")
+        run_filter_dataset(ssfn, ofn, -1, "none")
+        run_filter_dataset(ssfn, ofn, "-1", "blah")
+        run_filter_dataset(ssfn, ofn, "-1", "None, None")
+        run_filter_dataset(ssfn, ofn, "1.0", "None, None")
+        run_filter_dataset(ssfn, ofn, " 1.0 ", "None, None")
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, " 1. 0 ", "None, None")
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, "1. 0", "None, None")
+        run_filter_dataset(ssfn, ofn, "10.0", "None, None")
+        run_filter_dataset(ssfn, ofn, "0.01", "None, None")
+        run_filter_dataset(ssfn, ofn, "100000.01", "None, None")
+        run_filter_dataset(ssfn, ofn, ".00", "None, None")
+        run_filter_dataset(ssfn, ofn, 1.0, "None, None")
+        run_filter_dataset(ssfn, ofn, 10.0, "None, None")
+        run_filter_dataset(ssfn, ofn, 0.01, "None, None")
+        run_filter_dataset(ssfn, ofn, 100000.01, "None, None")
+        run_filter_dataset(ssfn, ofn, 100000, "None, None")
+        run_filter_dataset(ssfn, ofn, .00, "None, None")
+        run_filter_dataset(ssfn, ofn, 1., "None, None")
+        run_filter_dataset(ssfn, ofn, "1.", "None, None")
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, "None.1", "None, None")
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, "None1", "None, None")
+        with self.assertRaises(ValueError):
+            run_filter_dataset(ssfn, ofn, "1.1None", "None, None")
+
+        self.assertEqual(None, sanitize_read_length(""))
+        self.assertEqual(None, sanitize_read_length(0))
+        self.assertEqual(None, sanitize_read_length(0))
+        with self.assertRaises(ValueError):
+            sanitize_read_length("None")
+        self.assertEqual(None, sanitize_read_length(None))
+        self.assertEqual(None, sanitize_read_length(0))
+        self.assertEqual(None, sanitize_read_length(False))
+        with self.assertRaises(ValueError):
+            sanitize_read_length(True)
+        self.assertEqual(None, sanitize_read_length(False))
+        with self.assertRaises(ValueError):
+            sanitize_read_length(True)
+        self.assertEqual(1, sanitize_read_length(1))
+        self.assertEqual(0, sanitize_read_length("0"))
+        self.assertEqual(0, sanitize_read_length(" 0 "))
+        self.assertEqual(-1, sanitize_read_length("-1"))
+        self.assertEqual(-1, sanitize_read_length(" -1 "))
+        self.assertEqual(-1, sanitize_read_length(-1))
+        self.assertEqual(1, sanitize_read_length("1.0"))
+        self.assertEqual(1, sanitize_read_length(" 1.0 "))
+        self.assertEqual(1, sanitize_read_length(1.0))
+        with self.assertRaises(ValueError):
+            sanitize_read_length(" 1. 0 ")
+        with self.assertRaises(ValueError):
+            sanitize_read_length("1. 0")
+        self.assertEqual(10, sanitize_read_length("10.0"))
+        self.assertEqual(10, sanitize_read_length(10.0))
+        self.assertEqual(0, sanitize_read_length("0.01"))
+        self.assertEqual(0, sanitize_read_length(0.01))
+        self.assertEqual(100000, sanitize_read_length("100000.01"))
+        self.assertEqual(100000, sanitize_read_length(100000.01))
+        self.assertEqual(100000, sanitize_read_length(100000))
+        # These two are somewhat annoying:
+        self.assertEqual(0, sanitize_read_length(".00"))
+        self.assertEqual(None, sanitize_read_length(.00))
+        self.assertEqual(1, sanitize_read_length(1.))
+        self.assertEqual(1, sanitize_read_length("1."))
+        with self.assertRaises(ValueError):
+            sanitize_read_length("None.1")
+        with self.assertRaises(ValueError):
+            sanitize_read_length("None1")
+        with self.assertRaises(ValueError):
+            sanitize_read_length("1.1None")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tasks_filters.py
+++ b/tests/unit/test_tasks_filters.py
@@ -1,6 +1,4 @@
 
-import tempfile
-import unittest
 import logging
 import os.path as op
 
@@ -8,7 +6,6 @@ from pbcore.io import (FastaReader, FastqReader, openDataSet, HdfSubreadSet,
                        SubreadSet, ConsensusReadSet)
 import pbcore.data.datasets as data
 from pbcommand.testkit import PbTestApp
-from pbcommand.utils import which
 
 from base import get_temp_file
 
@@ -20,10 +17,6 @@ SIV_DATA_DIR = "/pbi/dept/secondary/siv/testdata"
 
 def _to_skip_msg(exe):
     return "Missing {e} or {d}".format(d=SIV_DATA_DIR, e=exe)
-
-# XXX hacks to make sure tools are actually available
-HAVE_DATA_DIR = op.isdir(SIV_DATA_DIR)
-
 
 class TestFilterDataSet(PbTestApp):
     TASK_ID = "pbcoretools.tasks.filterdataset"
@@ -56,6 +49,6 @@ class TestFilterDataSet(PbTestApp):
 
     def run_after(self, rtc, output_dir):
         n_expected, n_actual = self._get_counts(rtc)
-        self.assertEqual(self._get_filters(rtc), "( length >= 0 AND length <= 1400 )")
+        self.assertEqual(self._get_filters(rtc), "( length <= 1400 )")
         self.assertEqual(n_actual, n_expected)
 


### PR DESCRIPTION
The other_filters field is harder to sanitize, leaving alone for
now. A bunch of stuff is caught by the filter list parser.

Added tests to the sanitizer and smoke tests for the dataset filter task.