### PR TITLE
bug fixes to gather_fastq

### DIFF
--- a/pbcoretools/chunking/gather.py
+++ b/pbcoretools/chunking/gather.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from functools import partial as P
 import argparse
 import logging
+import shutil
 import json
 import os.path as op
 import sys
@@ -201,13 +202,14 @@ def __gather_contigset(resource_file_extension, input_files, output_file,
 gather_contigset = P(__gather_contigset, "fasta")
 
 def gather_fastq_contigset(input_files, output_file):
-    contigset_name = op.splitext(output_file)[0] + ".contigset.xml"
-    __gather_contigset("fastq", input_files, contigset_name,
-        new_resource_file=output_file)
-    # FIXME this will fail under certain circumstances - need to debug further
-    # (possibly just an artifact of unit test setup)
-    assert op.isfile(output_file)
-    return output_file
+    if len(input_files) == 1:
+        shutil.copyfile(input_files[0], output_file)
+    else:
+        contigset_name = op.splitext(output_file)[0] + ".contigset.xml"
+        __gather_contigset("fastq", input_files, contigset_name,
+            new_resource_file=output_file)
+        assert op.isfile(output_file)
+        return output_file
 
 
 def __gather_readset(dataset_type, input_files, output_file, skip_empty=True,

--- a/pbcoretools/tasks/gather_fastq.py
+++ b/pbcoretools/tasks/gather_fastq.py
@@ -9,15 +9,17 @@ from pbcoretools.chunking.gather import run_main_gather_fastq_contigset
 
 log = logging.getLogger(__name__)
 
-TOOL_ID = "pbcoretools.tasks.gather_fastq"
-CHUNK_KEY = "$chunk.fastq_id"
+class Constants(object):
+    TOOL_ID = "pbcoretools.tasks.gather_fastq"
+    CHUNK_KEY = "$chunk.fastq_id"
+    CHUNK_KEY_ID = "pbcoretools.task_options.dev_scatter_chunk_key"
 
 
 def get_contract_parser():
     driver = "python -m pbcoretools.tasks.gather_fastq --resolved-tool-contract "
 
-    p = get_gather_pbparser(TOOL_ID, "0.1.3", "Gather Fastq",
-                            "Gather Fastq", driver, is_distributed=False)
+    p = get_gather_pbparser(Constants.TOOL_ID, "0.1.3", "Gather Fastq",
+                            "Gather Fastq", driver, is_distributed=True)
 
     p.add_input_file_type(FileTypes.CHUNK, "cjson_in", "Gather ChunkJson",
                           "Fastq Gather Chunk JSON")
@@ -26,13 +28,14 @@ def get_contract_parser():
                            "Fastq Gathered",
                            "file_gathered.fastq")
 
-    p.add_str("pbcoretools.task_options.dev_scatter_chunk_key", "chunk_key",
+    p.add_str(Constants.CHUNK_KEY_ID, "chunk_key",
               "$chunk:fastq_id", "Chunk key", "Chunk key to use (format $chunk:{chunk-key}")
     return p
 
 
 def args_runner(args):
-    return run_main_gather_fastq_contigset(args.cjson_in, args.fastq_out, CHUNK_KEY)
+    return run_main_gather_fastq_contigset(args.cjson_in, args.fastq_out,
+        args.chunk_key)
 
 
 def rtc_runner(rtc):
@@ -41,7 +44,7 @@ def rtc_runner(rtc):
     :return:
     """
     # the input file is just a sentinel file
-    return run_main_gather_fastq_contigset(rtc.task.input_files[0], rtc.task.output_files[0], CHUNK_KEY)
+    return run_main_gather_fastq_contigset(rtc.task.input_files[0], rtc.task.output_files[0], rtc.task.chunk_key)
 
 
 def main(argv=sys.argv):


### PR DESCRIPTION
1. Pass chunk_key to gather function
2. Handle case where input is a single empty FASTQ file and ContigSet.consolidate() does not write a new file