### PR TITLE
Guess the desired DS type if none is specified to dataset create

### DIFF
--- a/pbcoretools/DataSetEntryPoints.py
+++ b/pbcoretools/DataSetEntryPoints.py
@@ -5,7 +5,7 @@ import argparse
 import string
 import re
 from collections import defaultdict
-from pbcore.io import DataSet, ContigSet, openDataSet
+from pbcore.io import DataSet, ContigSet, openDataSet, openDataFile
 from pbcore.io.dataset.DataSetMembers import Filters, OPMAP
 from pbcore.io.dataset.DataSetValidator import validateFile
 import logging
@@ -33,10 +33,15 @@ def summarize_options(parser):
     parser.set_defaults(func=summarizeXml)
 
 def createXml(args):
-    dsTypes = DataSet.castableTypes()
-    dset = dsTypes[args.dsType](*args.infile, strict=args.strict,
-                                skipCounts=args.skipCounts,
-                                generateIndices=args.generateIndices)
+    if args.dsType is None:
+        dset = openDataFile(*args.infile, strict=args.strict,
+                            skipCounts=args.skipCounts,
+                            generateIndices=args.generateIndices)
+    else:
+        dsTypes = DataSet.castableTypes()
+        dset = dsTypes[args.dsType](*args.infile, strict=args.strict,
+                                    skipCounts=args.skipCounts,
+                                    generateIndices=args.generateIndices)
     if args.generateIndices:
         # we generated the indices with the last open, lets capture them with
         # this one:
@@ -59,7 +64,7 @@ def create_options(parser):
     #parser.add_argument("infile", type=validate_file, nargs='+',
     parser.add_argument("infile", type=str, nargs='+',
                         help="The fofn or BAM file(s) to make into an XML")
-    parser.add_argument("--type", type=str, default='DataSet',
+    parser.add_argument("--type", type=str, default=None,
                         dest='dsType', help="The type of XML to create")
     parser.add_argument("--name", type=str, default='',
                         dest='dsName', help="The name of the new DataSet")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython
 numpy >= 1.7.1
 h5py >= 2.0.1
-pysam >= 0.8.3
+pysam >= 0.9.0
 pbcommand >= 0.3.25

--- a/tests/unit/test_pbvalidate_bam.py
+++ b/tests/unit/test_pbvalidate_bam.py
@@ -133,7 +133,7 @@ def generate_data_files(dir_name=None):
     with open("tst1.fasta", "w") as f:
         f.write(">ecoliK12_pbi_March2013_2955000_to_2980000\n")
         f.write("AAAGAGAGAG" * 2500)
-    pysam.faidx("tst1.fasta")
+    pysam.samtools.faidx("tst1.fasta", catch_stdout=False)
     for i in range(len(sam_strings)):
         sam_file = "tst_%d_subreads.sam" % (i + 1)
         bam_file = "tst_%d_subreads.bam" % (i + 1)

--- a/tests/unit/test_tasks_scatter_gather.py
+++ b/tests/unit/test_tasks_scatter_gather.py
@@ -42,7 +42,7 @@ def _write_fasta_or_contigset(file_name, make_faidx=False, n_records=251,
         f.write("\n".join(rec))
         f.flush()
     if make_faidx:
-        pysam.faidx(fasta_file)
+        pysam.samtools.faidx(fasta_file, catch_stdout=False)
     if file_name.endswith(".xml"):
         cs = ds_class(fasta_file, strict=make_faidx)
         cs.write(file_name)
@@ -462,7 +462,7 @@ class TestGatherContigs(_SetupGatherApp):
     def _generate_chunk_output_file(self, i=None):
         fn = tempfile.NamedTemporaryFile(suffix=".fasta").name
         write_random_fasta_records(fn)
-        pysam.faidx(fn)
+        pysam.samtools.faidx(fn, catch_stdout=False)
         return self._make_dataset_file(fn)
 
 
@@ -478,7 +478,7 @@ class TestGatherContigsConsolidate(TestGatherContigs):
         with open(fn, "w") as f:
             header, seq = self.CHUNK_CONTIGS[i]
             f.write(">{h}{s}\n{q}".format(h=header, s=suffix, q=seq))
-        pysam.faidx(fn)
+        pysam.samtools.faidx(fn, catch_stdout=False)
         return self._make_dataset_file(fn)
 
     def run_after(self, rtc, output_dir):


### PR DESCRIPTION
This should be non-ambiguous for all but fasta files, but we'll see if anything
becomes a recurring issue (like detected barcodes or mapping when the file is empty).

The alternative is to just create DataSets, which users almost never want to do on purpose.