### PR TITLE
Add warning if unable to update counts for dataset summarize

### DIFF
--- a/pbcoretools/dataset.py
+++ b/pbcoretools/dataset.py
@@ -17,9 +17,13 @@ def get_subparsers():
            ('merge', EntryPoints.merge_options),
            ('split', EntryPoints.split_options),
            ('validate', EntryPoints.validate_options),
-           ('loadstats', EntryPoints.loadStatsXml_options),
            ('summarize', EntryPoints.summarize_options),
-           ('consolidate', EntryPoints.consolidate_options)]
+           ('consolidate', EntryPoints.consolidate_options),
+           ('loadstats', EntryPoints.loadStatsXml_options),
+           ('newuuid', EntryPoints.newUniqueId_options),
+           ('loadmetadata', EntryPoints.loadMetadataXml_options),
+           ('copyto', EntryPoints.copyTo_options),
+          ]
     return sps
 
 def add_subparsers(parser, sps):


### PR DESCRIPTION
- Also add newuuid dataset subparser, which refreshes a dataset's uuid. Note
  that this is still a hex digest, so identical XMLs will still have identical
  UniqueIds.
- Also add copyto dataset subparser, which copies a dataset and resources to a
  new location and updates the dataset. Doesn't maintain directory structure,
  but should avoid naming collisions.
- Also add loadmetadata dataset subparser, which adds metadata from a
  run.metadata.xml file in one big chunk. Seems to be what ppa is doing, but
  use with caution.