### PR TITLE
Add outdir option to absolutize dataset subparser

### DIFF
--- a/pbcoretools/DataSetEntryPoints.py
+++ b/pbcoretools/DataSetEntryPoints.py
@@ -253,6 +253,8 @@ def relativizeXml(args):
     return 0
 
 def relativize_options(parser):
+    # doesn't make sense to have an outdir, that would screw with the relative
+    # paths...
     parser.description = 'Make the paths in an XML file relative'
     parser.add_argument("infile", type=str,
                         help="The XML file to relativize")
@@ -260,13 +262,21 @@ def relativize_options(parser):
 
 def absolutizeXml(args):
     dss = openDataSet(args.infile, strict=args.strict)
-    dss.write(args.infile, relPaths=False)
+    outfn = args.infile
+    if args.outdir:
+        if os.path.isdir(args.outdir):
+            outfn = _swapPath(args.outdir, args.infile)
+        else:
+            outfn = args.outdir
+    dss.write(outfn, relPaths=False)
     return 0
 
 def absolutize_options(parser):
     parser.description = 'Make the paths in an XML file absolute'
     parser.add_argument("infile", type=str,
                         help="The XML file to absolutize")
+    parser.add_argument("--outdir", default=None, type=str,
+                        help="Specify an optional output directory")
     parser.set_defaults(func=absolutizeXml)
 
 def copyToXml(args):

--- a/tests/unit/test_pbdataset.py
+++ b/tests/unit/test_pbdataset.py
@@ -170,6 +170,35 @@ class TestDataSet(unittest.TestCase):
         self.assertTrue(os.path.exists(fn))
         self.assertFalse(_is_relative(fn))
 
+        fn = tempfile.NamedTemporaryFile(suffix=".alignmentset.xml").name
+        outfn = tempfile.NamedTemporaryFile(suffix=".alignmentset.xml").name
+        aln = AlignmentSet(data.getXml(8))
+        aln.copyTo(fn, relative=True)
+        self.assertTrue(_is_relative(fn))
+        cmd = "dataset absolutize {d} --outdir {o}".format(d=fn, o=outfn)
+        log.debug(cmd)
+        o, r, m = backticks(cmd)
+        self.assertEqual(r, 0)
+        self.assertTrue(os.path.exists(fn))
+        self.assertTrue(os.path.exists(outfn))
+        self.assertTrue(_is_relative(fn))
+        self.assertFalse(_is_relative(outfn))
+
+        fn = tempfile.NamedTemporaryFile(suffix=".alignmentset.xml").name
+        outdir = tempfile.mkdtemp(suffix="dataset-unittest")
+        outfn = os.path.join(outdir, os.path.split(fn)[1])
+        aln = AlignmentSet(data.getXml(8))
+        aln.copyTo(fn, relative=True)
+        self.assertTrue(_is_relative(fn))
+        cmd = "dataset absolutize {d} --outdir {o}".format(d=fn, o=outdir)
+        log.debug(cmd)
+        o, r, m = backticks(cmd)
+        self.assertEqual(r, 0)
+        self.assertTrue(os.path.exists(fn))
+        self.assertTrue(os.path.exists(outfn))
+        self.assertTrue(_is_relative(fn))
+        self.assertFalse(_is_relative(outfn))
+
     @unittest.skipIf(not _check_constools(),
                      "bamtools or pbindex not found, skipping")
     def test_loadmetadata_cli(self):


### PR DESCRIPTION
so you don't have to absolutize a file in place, where the relative paths make sense, but where you may not have write permissions.